### PR TITLE
Use RbConfig instead of obsolete and deprecated Config

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -788,7 +788,7 @@ class ToplevelInstaller
     else
       require 'rbconfig'
     end
-    ::Config::CONFIG
+    ::RbConfig::CONFIG
   end
 
   def initialize(ardir_root, config)


### PR DESCRIPTION
Hello,
on ruby 2.3.2 setup.rb will break. I propose this patch to fix the error:

setup.rb:791:in `load_rbconfig': uninitialized constant Config (NameError)
	from setup.rb:771:in `invoke'
	from setup.rb:1619:in `<main>'