### PR TITLE
Fix utf8 encoding for ruby 191 and later

### DIFF
--- a/sapnwrfc.linux.gemspec
+++ b/sapnwrfc.linux.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |spec|
     sapnwrfc is a ruby module for performing RFC functions and BAPI calls on
     an SAP Netweaver system NW2004+
   EOF
-  spec.version = '0.26'
+  spec.version = '0.27'
   spec.homepage = 'http://www.piersharding.com'
   spec.files = Dir['lib/**/*.rb']
   spec.files += Dir['ext/nwsaprfc/nwsaprfc.c']
-  spec.required_ruby_version = '>= 1.8.0'
+  spec.required_ruby_version = '>= 1.9.1'
   spec.require_paths = ['ext/nwsaprfc', 'lib']
   spec.extensions = %w[ext/nwsaprfc/extconf.rb]
 end

--- a/sapnwrfc.linux.gemspec
+++ b/sapnwrfc.linux.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'http://www.piersharding.com'
   spec.files = Dir['lib/**/*.rb']
   spec.files += Dir['ext/nwsaprfc/nwsaprfc.c']
+  spec.files += Dir['tools/u16lit.pl']
   spec.required_ruby_version = '>= 1.9.1'
   spec.require_paths = ['ext/nwsaprfc', 'lib']
   spec.extensions = %w[ext/nwsaprfc/extconf.rb]


### PR DESCRIPTION
Ruby 1.9.1 and later tracks the encoding of every string, so all strings must be declared with an encoding that matches their actual content.
Without this patch the SAP strings are marked as ASCII-8BIT and are displaying incorrectly.
This is fixed by marking the SAP returned strings as UTF-8 strings.

In passing I also fixed a missing include that causes the gem installation build of the C extension to fail.
Tested in with ruby 1.9.3-p551.
